### PR TITLE
feature: Add max characters for display in dropdown

### DIFF
--- a/.storybook/stories/dropdown/Dropdown.stories.tsx
+++ b/.storybook/stories/dropdown/Dropdown.stories.tsx
@@ -23,7 +23,8 @@ export const Default = Template.bind({});
 Default.args = {
     data: [
         'Aasta Hanseen',
-        'Johan Sverdrup',
+        'Johan Sverdrup operation & project',
+        'Gullfaks Common documents (A+B+C+Veslefrikk)',
         'Johan Castberg',
         'Mongstad',
         'Aasta Hanseen',
@@ -36,5 +37,6 @@ Default.args = {
     showSearch: true,
     isDisabled: false,
     disabledText: 'Disabled while syncing or loading data',
+    maxCharacterCount: 24,
     position: 'absolute'
 };

--- a/.storybook/stories/dropdown/DropdownWrapper.tsx
+++ b/.storybook/stories/dropdown/DropdownWrapper.tsx
@@ -8,6 +8,7 @@ export interface DropdownWrapperProps {
     showSearch: boolean;
     isDisabled?: boolean;
     disabledText?: string;
+    maxCharacterCount?: number;
     variant?: 'compact' | 'default';
     position?: 'relative' | 'absolute';
 }
@@ -18,6 +19,7 @@ const TagContextMenuWrapper: React.FC<DropdownWrapperProps> = ({
     placeholder,
     isDisabled,
     disabledText,
+    maxCharacterCount,
     variant,
     showSearch,
     position
@@ -38,6 +40,7 @@ const TagContextMenuWrapper: React.FC<DropdownWrapperProps> = ({
                     placeholder={placeholder}
                     isDisabled={isDisabled}
                     disabledText={disabledText}
+                    maxCharacterCount={maxCharacterCount}
                     variant={variant}
                     showSearch={showSearch}
                     position={position}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-components",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Package for creating echo related components.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/__tests__/components/Dropdown.test.tsx
+++ b/src/__tests__/components/Dropdown.test.tsx
@@ -80,7 +80,7 @@ test('should show selected option when one is provided', () => {
         />
     );
 
-    expect(screen.getByTestId('display-text').textContent).toBe('Selected value ');
+    expect(screen.getByTestId('display-text').textContent).toBe('Selected value');
 });
 
 test('should show placeholder text if selected option is not provided', () => {
@@ -95,5 +95,5 @@ test('should show placeholder text if selected option is not provided', () => {
         />
     );
 
-    expect(screen.getByTestId('display-text').textContent).toBe('Placeholder text ');
+    expect(screen.getByTestId('display-text').textContent).toBe('Placeholder text');
 });

--- a/src/__tests__/snapshots/components/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/__tests__/snapshots/components/__snapshots__/Dropdown.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`renders dropdown with Default style and not showSearch correctly 1`] = 
       data-testid="display-text"
     >
       Placeholder text
-       
     </div>
     <svg
       aria-labelledby="eds-arrow_drop_down-8"
@@ -74,7 +73,6 @@ exports[`renders dropdown with Home style and showSearch correctly 1`] = `
       data-testid="display-text"
     >
       Placeholder text
-       
     </div>
     <svg
       aria-labelledby="eds-arrow_drop_down-4"

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -98,9 +98,8 @@ export const Dropdown: React.FC<DropdownItemProps> = ({
     const generateDisplayText = (text: string, characterLimit?: number): string => {
         if (!characterLimit || text.length <= characterLimit) {
             return text;
-        } else {
-            return text.slice(0, characterLimit).concat('...');
         }
+        return text.slice(0, characterLimit).concat('...');
     };
 
     const RenderDropdown = (): JSX.Element => {
@@ -171,7 +170,7 @@ export const Dropdown: React.FC<DropdownItemProps> = ({
                 title={isDisabled ? disabledText : 'Choose an option'}
             >
                 <div data-testid="display-text">
-                    {selected.length > 0 ? generateDisplayText(selected, maxCharacterCount) : placeholder}{' '}
+                    {selected.length > 0 ? generateDisplayText(selected, maxCharacterCount) : placeholder}
                 </div>
                 <Icon
                     name="arrow_drop_down"

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ interface DropdownItemProps {
     filterFunc?: (data: any[], filter: string) => any[];
     isDisabled?: boolean;
     disabledText?: string;
+    maxCharacterCount?: number;
     variant?: 'compact' | 'default';
     showSearch: boolean;
     position?: 'relative' | 'absolute';
@@ -50,6 +51,7 @@ export const Dropdown: React.FC<DropdownItemProps> = ({
     setSelected,
     isDisabled,
     disabledText = 'Disabled',
+    maxCharacterCount,
     variant,
     showSearch,
     position = 'absolute',
@@ -91,6 +93,14 @@ export const Dropdown: React.FC<DropdownItemProps> = ({
     const handleSetFilter = (event: React.ChangeEvent<HTMLInputElement>): void => {
         event.stopPropagation();
         setFilter(event.currentTarget.value);
+    };
+
+    const generateDisplayText = (text: string, characterLimit?: number): string => {
+        if (!characterLimit || text.length <= characterLimit) {
+            return text;
+        } else {
+            return text.slice(0, characterLimit).concat('...');
+        }
     };
 
     const RenderDropdown = (): JSX.Element => {
@@ -160,7 +170,9 @@ export const Dropdown: React.FC<DropdownItemProps> = ({
                 onClick={(event: React.MouseEvent): void => handleIsOpenToggle(event)}
                 title={isDisabled ? disabledText : 'Choose an option'}
             >
-                <div data-testid="display-text">{selected.length > 0 ? selected : placeholder} </div>
+                <div data-testid="display-text">
+                    {selected.length > 0 ? generateDisplayText(selected, maxCharacterCount) : placeholder}{' '}
+                </div>
                 <Icon
                     name="arrow_drop_down"
                     title="Choose options"


### PR DESCRIPTION
In some cases we may want to limit the number of characters displayed in the dropdown. Added option to set this limit, and the display text will have ellipsis (...) appended to it.

![image](https://user-images.githubusercontent.com/74668394/119661107-40cfcd00-be30-11eb-92dc-412ef5e60636.png)
