### PR TITLE
fix: added z-index on the data info popover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-components",
-    "version": "0.1.4",
+    "version": "0.1.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-components",
-            "version": "0.1.4",
+            "version": "0.1.6",
             "license": "MIT",
             "dependencies": {
                 "react-sortablejs": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-components",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Package for creating echo related components.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/components/contextMenuPopover/dataInfoPopover.module.css
+++ b/src/components/contextMenuPopover/dataInfoPopover.module.css
@@ -3,6 +3,7 @@
     flex-direction: column;
     right: 0px;
     position: absolute;
+    z-index: 10;
 }
 
 .arrow {


### PR DESCRIPTION
DataInfo popoveren trengte en z-index. Nå havner den under alt annet innhold

![image](https://user-images.githubusercontent.com/54531804/123949233-a0c31180-d9a2-11eb-8234-e969d0d4869c.png)
